### PR TITLE
Add missing description

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# MoLFormer Inference for SMILES
+# MoLFormer / Property Prediction Highlights on SMILES Input
 
 <!--
 The description & support tags are consumed by the generate_docs() script
@@ -10,6 +10,7 @@ https://openad.accelerate.science/docs/model-service/available-services
 <!-- support:gcloud:false -->
 
 <!-- description -->
+MoLFormer / Three finetuned property prediction models on MoleculeNet tasks: BACE classification, ClinTox multiclass, and QM9 alpha regression.
 <!-- /description -->
 
 For instructions on how to deploy and use this service in OpenAD, please refer to the [OpenAD docs](https://openad.accelerate.science/docs/model-service/deploying-models).


### PR DESCRIPTION
Description was missing, so I checked what models are included and added a description in line with others I have been editing in openad-service-* repos, which are consumed by @themoenen script to create OpenAD model service docs.